### PR TITLE
Updated default export and changed readme to accomodate

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ If you're developing using npm and CommonJS modules:
 let analytics = require('react-segment');
 
 if(process.env.NODE_ENV == 'development'){
-    analytics.default.load("DEVELOPMENT KEY");
+    analytics.load("DEVELOPMENT KEY");
 }else if(process.env.NODE_ENV == 'staging' ){
-    analytics.default.load("STAGING KEY");
+    analytics.load("STAGING KEY");
 }else if(process.env.NODE_ENV == 'pre-production'){
-    analytics.default.load("PRE-PRODUCTION KEY");
+    analytics.load("PRE-PRODUCTION KEY");
 }else if(process.env.NODE_ENV == 'production'){
-    analytics.default.load("PRODUCTION KEY");
+    analytics.load("PRODUCTION KEY");
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var analytics = function() {
+const analytics = function() {
     var analytics = window.analytics = window.analytics || [];
     if (!analytics.initialize)
         if (analytics.invoked) window.console && console.error && console.error("Segment snippet included twice.");
@@ -32,4 +32,4 @@ var analytics = function() {
   return analytics;
 }();
 
-exports.default = analytics;
+export default analytics;

--- a/package.json
+++ b/package.json
@@ -112,5 +112,5 @@
     "url": "git+https://github.com/anishmprasad/react-segment.git"
   },
   "scripts": {},
-  "version": "0.1.7"
+  "version": "0.2.0"
 }


### PR DESCRIPTION
Hey! thanks for this package! Nice little thingy to make it less awkward to work with the segment javascript SDK in a more "reactful" way :) 

I changed the export to make sure you don't have to do `analytics.default.page` etc when using. Updated the readme as well to reflect and bumped the version.

This is a breaking change though, so might actually want to do "1.0.0) instead, but yeah it's also not a huge deal I guess.